### PR TITLE
Make deployed application name consistent with the repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Repository for the elements, components and patterns of the DTO. It is both a 
 
 It is very much a **work-in-progress** and not ready for general use.
 
-It can be accessed at https://universal-design-guide.apps.staging.digital.gov.au/
+It can be accessed at https://gov-au-design-guide.apps.staging.digital.gov.au/
 
 This will remain **password protected** until the design guide is ready for general release.
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ title: Design Guide
 email: admin@digital.gov.au
 description: Design Guide
 baseurl: "" # the subpath of your site, e.g. /blog
-url: 'http://universal-design-guide.apps.staging.digital.gov.au' # the base hostname & protocol for your site
+url: 'http://gov-au-design-guide.apps.staging.digital.gov.au' # the base hostname & protocol for your site
 
 gems: [bourbon, neat]
 
@@ -28,7 +28,7 @@ assets:
 
 prose:
   rooturl: '_includes/content'
-  siteurl: 'http://universal-design-guide.apps.staging.digital.gov.au/'
+  siteurl: 'http://gov-au-design-guide.apps.staging.digital.gov.au/'
   ignore:
     - _config.yml
     - /_assets

--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -5,4 +5,4 @@ set -e
 # Output the commands we run
 set -x
 
-cf push universal-design-guide -b staticfile_buildpack -p ./_site -i 1
+cf push gov-au-design-guide -b staticfile_buildpack -p ./_site -i 1


### PR DESCRIPTION
Also fixes the name of the repository in the README that was referring to the old name
