### PR TITLE
Topbar header color & compatibility for text to sit w/ or w/o branding

### DIFF
--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -96,8 +96,11 @@ p.index-description {
 // end style guide index
 
 // style guide header
+
+$dto-colour: #015a96;
+
 header {
-  background-color: #244A61;
+  background-color: $dto-colour;
   color: white;
   height: 80px;
   position: fixed;
@@ -114,10 +117,6 @@ header {
       letter-spacing: 0px;
       line-height: 80px;
       margin: 0;
-
-      &:last-child {
-        padding-left: 94px;
-      }
     }
   }
 }
@@ -138,6 +137,10 @@ header {
   position: relative;
   top: 14px;
   width: 53px;
+
+  & + p {
+    padding-left: 94px;
+  }
 }
 // end style guide header
 


### PR DESCRIPTION
This change is added b/c the content guide topbar does not use the branding logo so the text needs to sit flush left.

Also, dto colour change.