### PR TITLE
Remove HTTP password by deleting Staticfile.auth

### DIFF
--- a/Staticfile.auth
+++ b/Staticfile.auth
@@ -1,1 +1,0 @@
-dto:$apr1$fBQ.99Ka$Ir1fu/.uQBw2JqFwl.pUE.


### PR DESCRIPTION
If this repository is already public on github, can we remove the HTTP password so the style sheet can be used directly without having that password or hardcoding it in our templates?
